### PR TITLE
Add redeploy script based on Week 3 script activity.

### DIFF
--- a/app/scripts/redeploy.sh
+++ b/app/scripts/redeploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Reset environment and update project.
+tmux kill-server;
+cd "~/repos/project-placeholder";
+git stash && git switch main && git fetch --all && git reset --hard origin/main;
+
+# Boot process.
+tmux new-session -d -s process "cd ~/repos/project-placeholder && source venv/bin/activate && pip install -q -r requirements.txt && flask run --host=0.0.0.0";


### PR DESCRIPTION
## Description

Implement `redeploy.sh` script based on _Week 3: Automate Deployment with Scripting_ activity. This script can be run with the following command inside the project folder: `sh scripts/redeploy.sh`.

Note: I had to hardcode the repository path to `~/repos/project-placeholder` to avoid issues with parts of the script that reference the repository's local relative location (i.e. move your project to the same location inside the CentOS server).

## Tasks

- Implement script.
